### PR TITLE
Fixes Partial Common Path Matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ function isMarkdown (data) {
 
 // Find the common parent directory given an array of files.
 function findCommonDir (files) {
-  const path = files.reduce((path, file) => {
+  const path = files.reduce((path, file, fileIndex) => {
     // If it's a file not in any directory then just skip it
     // by assigning the previous value.
     if (!file.includes('/')) {
@@ -308,22 +308,29 @@ function findCommonDir (files) {
     }
 
     // No path set yet
-    if (!path) {
-      return file;
+    if (!path && fileIndex === 0) {
+      return file.substr(0, file.lastIndexOf('/') + 1);
     } else {
-      const sharedIndex = Array.from(path).findIndex((element, index) => {
+      // Get index of last shared character
+      let sharedIndex = Array.from(path).findIndex((element, index) => {
         if (file[index] !== element) {
           return index - 1;
         }
       });
 
+      // Round to nearest full directory
       if (sharedIndex > -1) {
-        const sharedPath = path.substr(0, sharedIndex);
-        return sharedPath.substr(0, sharedPath.lastIndexOf('/') + 1);
+        sharedIndex = path.substr(0, sharedIndex).lastIndexOf('/');
+      }
+
+      // Return shared directory path
+      if (sharedIndex > -1) {
+        return path.substr(0, sharedIndex + 1);
       } else if (file.startsWith(path)) {
         return path;
       }
 
+      // No shared directory path
       return '';
     }
   }, '');

--- a/index.js
+++ b/index.js
@@ -300,13 +300,33 @@ function isMarkdown (data) {
 
 // Find the common parent directory given an array of files.
 function findCommonDir (files) {
-  return files.reduce(function (p, c) {
-    // If it's a file not in any directory then just skip it by assigning the previous value.
-    if (c.indexOf('/') === -1) {
-      return p
+  const path = files.reduce((path, file) => {
+    // If it's a file not in any directory then just skip it
+    // by assigning the previous value.
+    if (!file.includes('/')) {
+      return path;
     }
-    return !p ? c : p.split('').filter((letter, i) => letter === c[i]).join('')
-  }, '')
+
+    // No path set yet
+    if (!path) {
+      return file;
+    } else {
+      const sharedIndex = Array.from(path).findIndex((element, index) => {
+        if (file[index] !== element) {
+          return index - 1;
+        }
+      });
+
+      if (sharedIndex > -1) {
+        const sharedPath = path.substr(0, sharedIndex);
+        return sharedPath.substr(0, sharedPath.lastIndexOf('/') + 1);
+      }
+
+      return '';
+    }
+  }, '');
+
+  return path;
 }
 
 // Remove body props from summary.

--- a/index.js
+++ b/index.js
@@ -320,6 +320,8 @@ function findCommonDir (files) {
       if (sharedIndex > -1) {
         const sharedPath = path.substr(0, sharedIndex);
         return sharedPath.substr(0, sharedPath.lastIndexOf('/') + 1);
+      } else if (file.startsWith(path)) {
+        return path;
       }
 
       return '';

--- a/index.test.js
+++ b/index.test.js
@@ -137,4 +137,13 @@ describe('processmd', () => {
       ])
     ).toBe('test/data/output/')
   })
+
+  it('#findCommonDir should match complete paths only', () => {
+    expect(
+      processmdLib._findCommonDir([
+        'content/pages',
+        'content/posts'
+      ])
+    ).toBe('content/')
+  })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -145,5 +145,25 @@ describe('processmd', () => {
         'content/posts'
       ])
     ).toBe('content/')
+
+    expect(
+      processmdLib._findCommonDir([
+        'pages/2016/about.md',
+        'posts/drafts/hello_world.md',
+        'posts/drafts/test_post.md'
+      ])
+    ).toBe('')
+
+    expect(
+      processmdLib._findCommonDir([
+        'pages/about.md'
+      ])
+    ).toBe('pages/')
+
+    expect(
+      processmdLib._findCommonDir([
+        'about.md'
+      ])
+    ).toBe('')
   })
 })


### PR DESCRIPTION
Fixes #7 - turns out it was the commonDir method. Given `['content/pages', 'content/posts']` it was returning `content/ps`. 

Having a heck of a time getting the test suite to run - I added a test, but most of them are failing even on a clean clone. Any help would be appreciated!