### PR TITLE
Fix File Param

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function processmd (options, callback) {
 
   options.markdownRenderer = options.markdownRenderer || function mdRender (str) { return markdownIt.render(str) }
 
-  const globs = (options.files || []).concat(options._)
+  const globs = (options.files || []).concat(options._ || [])
   if (globs.length === 0) {
     throw new Error('You must pass file patterns in to be processed.')
   }


### PR DESCRIPTION
Got another fix! Noticed when I pass a `file` option it from a custom script it would get concat with `undefined` since I wasn't using yargs to parse the options.