### PR TITLE
Attempt to parse markdown options as JSON

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,11 @@ const argv = require('yargs')
 
 if (process.argv && process.argv.length > 2) {
   const options = Object.assign({}, defaultOptions, argv)
+  try {
+    options.markdownOptions = JSON.parse(options.markdownOptions)
+  } catch (err) {
+    // noop: markdownOptions was not valid JSON, leave it as a string
+  }
 
   processmd(options, (err, data) => {
     if (err) {

--- a/index.test.js
+++ b/index.test.js
@@ -166,4 +166,45 @@ describe('processmd', () => {
       ])
     ).toBe('')
   })
+
+  it('should parse markdownOptions if argument is JSON', done => {
+    const cli = spawn('node', [
+      './cli.js',
+      'test/data/input/README.md',
+      '--includeBodyProps',
+      '--markdownOptions',
+      '{"linkify":true}',
+      '--stdout',
+      '--outputDir',
+      'test/data/output'
+    ])
+
+    const output = []
+    cli.stdout.on('data', data => {
+      output.push(data.toString())
+    })
+
+    cli.on('close', code => {
+      const parsedOutput = JSON.parse(output.join(''))
+      expect(parsedOutput.fileMap['test/data/output/README.json'].bodyHtml.indexOf('<a href=')).not.toEqual(-1)
+      expect(code).toEqual(0)
+      done()
+    })
+  })
+
+  it('should pass markdownOptions as a string if argument is not JSON (markdown-it preset name)', done => {
+    const cli = spawn('node', [
+      './cli.js',
+      'test/data/input/**/*.{yml,md}',
+      '--stdout',
+      '--outputDir',
+      'test/data/output',
+      '--markdownOptions zero'
+    ])
+
+    cli.on('close', code => {
+      expect(code).toEqual(0)
+      done()
+    })
+  })
 })

--- a/test/data/input/README.md
+++ b/test/data/input/README.md
@@ -1,3 +1,6 @@
 # processmd
 
 Process a directory of markdown and yaml files to JSON files
+
+Linkify check: https://www.github.com/tscanlin/processmd
+


### PR DESCRIPTION
The value of `--markdownOptions` was being passed as a string to the markdown-it constructor.  This change will cause the value to be `JSON.parse`'d if it is a valid JSON object, otherwise it is passed as-is.